### PR TITLE
LD - RequestType CRUD (Backend)

### DIFF
--- a/.github/workflows/82-kanban-slack-update.yml
+++ b/.github/workflows/82-kanban-slack-update.yml
@@ -5,7 +5,7 @@ name: "82-kanban-slack-update.yml"
 
 on:
   schedule:
-    - cron: "0 17 * * *"  # Run at 9:00 AM PST / 5:00 PM UTC
+    - cron: "0 0,17 * * *"  # 0,17 UTC are 4pm and 9am Pacific Time
   workflow_dispatch:  # Allows manual triggering
 
 env:
@@ -14,7 +14,7 @@ env:
   TEAM: ${{ github.repository }}
   ORG_NAME: ${{ github.repository_owner }}
   COLUMNS: "Todo, In Progress, In Review, Done"
-  END_DATE: "2024-11-13"  # Set the end date for the workflow
+  END_DATE: "2024-12-13"  # Set the end date for the workflow
 
 jobs:
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,7 @@
             <exclude>**/${app.packagePath}/services/CurrentUserServiceImpl.*</exclude>
             <exclude>**/${app.packagePath}/services/GrantedAuthoritiesService.*</exclude>
             <exclude>**/${app.packagePath}/ExampleApplication.*</exclude>
+            <exclude>**/${app.packagePath}/ExampleApplicationRunner.*</exclude>
             <exclude>**/${app.packagePath}/services/wiremock/*</exclude>
           </excludes>
         </configuration>
@@ -315,6 +316,7 @@
             <param>${app.package}.controllers.FrontendProxyController</param>
             <param>${app.package}.services.CurrentUserServiceImpl</param>
             <param>${app.package}.ExampleApplication</param>
+            <param>${app.package}.ExampleApplicationRunner</param>
             <param>${app.package}.config.SecurityConfig</param>
             <param>${app.package}.config.SpaCsrfTokenRequestHandler</param>
             <param>${app.package}.config.CsrfCookieFilter</param>

--- a/src/main/java/edu/ucsb/cs156/rec/ExampleApplicationRunner.java
+++ b/src/main/java/edu/ucsb/cs156/rec/ExampleApplicationRunner.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.rec;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.services.RequestTypeService;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Configuration;
+
+/** This class contains a `run` method that is called once at application startup time. */
+@Slf4j
+@Configuration
+public class ExampleApplicationRunner implements ApplicationRunner {
+  @Autowired RequestTypeService requestTypeService;
+
+  /**
+   * Called once at application startup time. Put code here if you want it to run once each time the
+   * Spring Boot application starts up.
+   */
+  @Override
+  public void run(ApplicationArguments args) throws Exception {
+    log.info("ExampleApplicationRunner.run called");
+
+    String[] beginningTypes = new String[] {"CS Department BS/MS program",
+    "Scholarship or Fellowship",
+    "MS program (other than CS Dept BS/MS)",
+    "PhD program",
+    "Other"};
+
+    List<RequestType> requestTypes = new ArrayList<RequestType>();
+
+    for (String type : beginningTypes) {
+      RequestType saving = new RequestType();
+      saving.setRequestType(type);
+      requestTypes.add(saving);
+    }
+
+    requestTypeService.trySaveTypes(requestTypes);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/ApiController.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.rec.controllers;
 
+import edu.ucsb.cs156.rec.errors.EntityAlreadyExistsException;
 import edu.ucsb.cs156.rec.errors.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -46,6 +47,20 @@ public abstract class ApiController {
   @ExceptionHandler({ EntityNotFoundException.class })
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public Object handleGenericException(Throwable e) {
+    return Map.of(
+      "type", e.getClass().getSimpleName(),
+      "message", e.getMessage()
+    );
+  }
+
+  /**
+   * This method handles the EntityAlreadyExistsException.
+   * @param e the exception
+   * @return a map with the type and message of the exception
+   */
+  @ExceptionHandler({ EntityAlreadyExistsException.class })
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public Object handleGenericException(EntityAlreadyExistsException e) {
     return Map.of(
       "type", e.getClass().getSimpleName(),
       "message", e.getMessage()

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
@@ -1,0 +1,126 @@
+package edu.ucsb.cs156.rec.controllers;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.errors.EntityNotFoundException;
+import edu.ucsb.cs156.rec.errors.EntityAlreadyExistsException;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import edu.ucsb.cs156.rec.services.RequestTypeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+/**
+ * This is a REST controller for Request Types
+ */
+
+@Tag(name = "RequestTypes")
+@RequestMapping("/api/requesttypes")
+@RestController
+@Slf4j
+public class RequestTypesController extends ApiController {
+
+    @Autowired
+    RequestTypeRepository requestTypeRepository;
+
+	@Autowired
+	RequestTypeService requestTypeService;
+
+    /**
+     * This method returns a list of all request types.
+     * @return a list of all request types
+     */
+    @Operation(summary = "List all request types")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<RequestType> allRequestTypes() {
+        Iterable<RequestType> requestTypes = requestTypeRepository.findAll();
+        return requestTypes;
+    }
+
+    /**
+     * This method returns a single request type.
+     * @param id id of the request type to get
+     * @return a single request type
+     */
+    @Operation(summary = "Get a single request type")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public RequestType getById(
+            @Parameter(name = "id") @RequestParam Long id) {
+		RequestType requestType = requestTypeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RequestType.class, id));
+
+        return requestType;
+    }
+
+    /**
+     * This method creates a new request type. Accessible only to users with the role "ROLE_ADMIN" or "ROLE_INSTRUCTOR".
+     * @param requestType description of the request type
+     * @return the save request type (with it's id field set by the database)
+     */
+    @Operation(summary = "Create a new request type")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_INSTRUCTOR')")
+    @PostMapping("/post")
+    public RequestType postRequestType(
+            @Parameter(name = "requestType") @RequestParam String requestType) {
+        
+        RequestType savingRequestType = new RequestType();
+        savingRequestType.setRequestType(requestType);
+
+        return requestTypeService.trySave(savingRequestType)
+				.orElseThrow(() -> new EntityAlreadyExistsException(RequestType.class, requestType));
+    }
+
+    /**
+     * Deletes a request type. Accessible only to users with the role "ROLE_ADMIN".
+     * @param id id of the request type to delete
+     * @return a message indicating that the request type was deleted
+     */
+    @Operation(summary = "Delete a Request Type")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_INSTRUCTOR')")
+    @DeleteMapping("")
+    public Object deleteRequestType(
+            @Parameter(name = "id") @RequestParam Long id) {
+		RequestType requestType = requestTypeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RequestType.class, id));
+
+		requestTypeRepository.delete(requestType);
+        return genericMessage("RequestType with id %s deleted".formatted(id));
+    }
+
+    /**
+     * Update a single request type. Accessible only to users with the role "ROLE_ADMIN".
+     * @param id id of the request type to update
+     * @param incoming the new request type contents
+     * @return the updated request type object
+     */
+    @Operation(summary = "Update a single request type")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_INSTRUCTOR')")
+    @PutMapping("")
+    public RequestType updateRequestType(
+            @Parameter(name = "id") @RequestParam Long id,
+            @RequestBody @Valid RequestType incoming) {
+
+		RequestType requestType = requestTypeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RequestType.class, id));
+
+        requestType.setRequestType(incoming.getRequestType());
+		
+		return requestTypeService.trySave(requestType)
+				.orElseThrow(() -> new EntityAlreadyExistsException(RequestType.class, incoming.getRequestType()));
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/rec/entities/RequestType.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/RequestType.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "requesttype")
+@Entity(name = "requesttypes")
 public class RequestType {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/rec/entities/RequestType.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/RequestType.java
@@ -1,0 +1,28 @@
+package edu.ucsb.cs156.rec.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a Request Type, i.e. a
+ * type of request that could occur
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "requesttype")
+public class RequestType {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requestType;
+}

--- a/src/main/java/edu/ucsb/cs156/rec/errors/EntityAlreadyExistsException.java
+++ b/src/main/java/edu/ucsb/cs156/rec/errors/EntityAlreadyExistsException.java
@@ -1,0 +1,18 @@
+package edu.ucsb.cs156.rec.errors;
+
+/**
+ * This is an error class for a custom RuntimeException in Java that is used to indicate
+ * when an entity of a specific type with a given ID already exists in the repository.
+ */
+public class EntityAlreadyExistsException extends RuntimeException {
+  /**
+   * Constructor for the exception
+   * 
+   * @param entityType The class of the entity that was not found, e.g. User.class
+   * @param type the type that was trying to be saved
+   */
+  public EntityAlreadyExistsException(Class<?> entityType, Object type) {
+    super("%s %s already exists"
+      .formatted(entityType.getSimpleName(), type.toString()));
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/rec/repositories/RequestTypeRepository.java
+++ b/src/main/java/edu/ucsb/cs156/rec/repositories/RequestTypeRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.rec.repositories;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The RequestTypeRepository is a repository for RequestType entities
+ */
+@Repository
+public interface RequestTypeRepository extends CrudRepository<RequestType, Long> {
+}

--- a/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeService.java
+++ b/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeService.java
@@ -1,0 +1,62 @@
+package edu.ucsb.cs156.rec.services;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * This is a service that provides information about the current user.
+ * 
+ * This is the version of the service used in production.
+ */
+
+@Slf4j
+@Service("RequestType")
+public class RequestTypeService {
+	
+	@Autowired
+	private RequestTypeRepository requestTypeRepository;
+
+	private boolean requestTypeExists(String type) {
+		boolean alreadyContains = false;
+		Iterable<RequestType> typeList = requestTypeRepository.findAll();
+
+		for (RequestType requestType : typeList) {
+			if (requestType.getRequestType().equals(type)) {
+				alreadyContains = true;
+				break;
+			}
+		}
+		return alreadyContains;
+	}
+
+	public Optional<RequestType> trySave(RequestType requestType) {
+		boolean alreadyContains = requestTypeExists(requestType.getRequestType());
+
+		if (alreadyContains) {
+			return Optional.empty();
+		}
+
+		return Optional.of(requestTypeRepository.save(requestType));
+	}
+
+	public List<RequestType> trySaveTypes(List<RequestType> toSave) {
+		List<RequestType> savedTypes = new ArrayList<RequestType>();
+
+		toSave.forEach((requestType) -> {
+			Optional<RequestType> saved = trySave(requestType);
+			if (saved.isPresent()) {
+				savedTypes.add(saved.get());
+			}
+		});
+
+		return savedTypes;
+	}
+}

--- a/src/main/resources/db/migration/changes/RequestType.json
+++ b/src/main/resources/db/migration/changes/RequestType.json
@@ -35,7 +35,7 @@
                   },
                   {
                     "column": {
-                      "name": "REQUESTTYPE",
+                      "name": "REQUEST_TYPE",
                       "type": "VARCHAR(255)"
                     }
                   }

--- a/src/main/resources/db/migration/changes/RequestType.json
+++ b/src/main/resources/db/migration/changes/RequestType.json
@@ -1,0 +1,50 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "RequestTypes-1",
+          "author": "lodetrick",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "REQUESTTYPES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "REQUESTTYPES_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTTYPE",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "REQUESTTYPES"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
@@ -1,0 +1,399 @@
+package edu.ucsb.cs156.rec.controllers;
+
+import edu.ucsb.cs156.rec.repositories.UserRepository;
+import edu.ucsb.cs156.rec.testconfig.TestConfig;
+import edu.ucsb.cs156.rec.ControllerTestCase;
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import edu.ucsb.cs156.rec.services.RequestTypeService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = RequestTypesController.class)
+@Import(TestConfig.class)
+public class RequestTypesControllerTests extends ControllerTestCase {
+
+        @MockBean
+        RequestTypeRepository requestTypeRepository;
+
+        @MockBean
+        RequestTypeService requestTypeService;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/phones/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/requesttypes?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // Authorization tests for /api/phones/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/requesttypes/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/requesttypes/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                RequestType requestType = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeRepository.findById(eq(7L))).thenReturn(Optional.of(requestType));  // Check not sure why id is 7
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/requesttypes?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(requestTypeRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(requestType);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(requestTypeRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/requesttypes?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(requestTypeRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("RequestType with id 7 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_request_types() throws Exception {
+
+                // arrange
+                
+                RequestType requestType1 = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+                
+                RequestType requestType2 = RequestType.builder()
+                                .requestType("Office Hours")
+                                .build();
+
+                ArrayList<RequestType> expectedRequestTypes = new ArrayList<>();
+                expectedRequestTypes.addAll(Arrays.asList(requestType1, requestType2));
+
+                when(requestTypeRepository.findAll()).thenReturn(expectedRequestTypes);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(requestTypeRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedRequestTypes);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_request_type() throws Exception {
+                // arrange
+
+                RequestType requestType1 = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeService.trySave(eq(requestType1))).thenReturn(Optional.of(requestType1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/requesttypes/post?requestType=Colloquia")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(requestTypeService, times(1)).trySave(requestType1);
+                String expectedJson = mapper.writeValueAsString(requestType1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "INSTRUCTOR", "USER" })
+        @Test
+        public void an_instructor_can_post_a_new_request_type() throws Exception {
+                // arrange
+
+                RequestType requestType1 = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeService.trySave(eq(requestType1))).thenReturn(Optional.of(requestType1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/requesttypes/post?requestType=Colloquia")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(requestTypeService, times(1)).trySave(requestType1);
+                String expectedJson = mapper.writeValueAsString(requestType1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_post_a_duplicate_request_type() throws Exception {
+                // arrange
+                RequestType requestType1 = RequestType.builder().id(0L)
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeService.trySave(requestType1)).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/requesttypes/post?requestType=Colloquia")
+                                                .with(csrf()))
+                                .andExpect(status().isBadRequest()).andReturn();
+
+                // assert
+                verify(requestTypeService, times(1)).trySave(requestType1);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityAlreadyExistsException", json.get("type"));
+                assertEquals("RequestType Colloquia already exists", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_request_type() throws Exception {
+                // arrange
+
+                RequestType requestType1 = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeRepository.findById(eq(15L))).thenReturn(Optional.of(requestType1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/requesttypes?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(requestTypeRepository, times(1)).findById(15L);
+                verify(requestTypeRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RequestType with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "INSTRUCTOR", "USER" })
+        @Test
+        public void instructor_can_delete_a_request_type() throws Exception {
+                // arrange
+
+                RequestType requestType1 = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeRepository.findById(eq(15L))).thenReturn(Optional.of(requestType1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/requesttypes?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(requestTypeRepository, times(1)).findById(15L);
+                verify(requestTypeRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RequestType with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_request_type_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(requestTypeRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/requesttypes?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(requestTypeRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RequestType with id 15 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_request_type() throws Exception {
+                // arrange
+                RequestType requestTypeOrig = RequestType.builder().id(67L)
+                                .requestType("Colloquia")
+                                .build();
+
+                RequestType requestTypeEdited = RequestType.builder().id(67L)
+                                .requestType("Colloquium")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(requestTypeEdited);
+
+                when(requestTypeService.trySave(eq(requestTypeEdited))).thenReturn(Optional.of(requestTypeEdited));
+                when(requestTypeRepository.findById(eq(67L))).thenReturn(Optional.of(requestTypeOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/requesttypes?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                
+                verify(requestTypeService, times(1)).trySave(requestTypeEdited);
+                verify(requestTypeRepository, times(1)).findById(67L);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_to_duplicate_request_type() throws Exception {
+                // arrange
+                RequestType requestTypeOrig = RequestType.builder().id(67L)
+                                .requestType("Colloquia")
+                                .build();
+
+                RequestType requestTypeEdited = RequestType.builder().id(67L)
+                                .requestType("Colloquium")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(requestTypeEdited);
+
+                when(requestTypeService.trySave(eq(requestTypeEdited))).thenReturn(Optional.empty());
+                when(requestTypeRepository.findById(eq(67L))).thenReturn(Optional.of(requestTypeOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/requesttypes?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isBadRequest()).andReturn();
+
+                // assert
+                verify(requestTypeService, times(1)).trySave(requestTypeEdited);
+                verify(requestTypeRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityAlreadyExistsException", json.get("type"));
+                assertEquals("RequestType Colloquium already exists", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_request_type_that_does_not_exist() throws Exception {
+                // arrange
+
+                RequestType editedrequestType = RequestType.builder()
+                                .requestType("Colloquium")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(editedrequestType);
+
+                when(requestTypeRepository.findById(eq(67L))).thenReturn(Optional.empty());
+                when(requestTypeService.trySave(eq(editedrequestType))).thenReturn(Optional.of(editedrequestType));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/requesttypes?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(requestTypeRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RequestType with id 67 not found", json.get("message"));
+
+        }
+}

--- a/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeServiceTests.java
@@ -83,4 +83,10 @@ class RequestTypeServiceTests extends ControllerTestCase {
 		verify(requestTypeRepository, times(1)).save(requestType2);
 		assertEquals(List.of(requestType0,requestType2), requestSaved);
 	}
+
+	@Test
+	void test_constructor() {
+		RequestTypeService service = new RequestTypeService();
+		assertEquals(RequestTypeService.class, service.getClass());
+	}
 }

--- a/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeServiceTests.java
@@ -1,0 +1,86 @@
+package edu.ucsb.cs156.rec.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import edu.ucsb.cs156.rec.ControllerTestCase;
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RequestTypeServiceTests extends ControllerTestCase {
+
+	@Mock
+	RequestTypeRepository requestTypeRepository;
+
+	@InjectMocks
+	RequestTypeService requestTypeService = mock(RequestTypeService.class, Answers.CALLS_REAL_METHODS);
+
+	@Test
+	void test_trySave_already_exists() {
+		RequestType req = RequestType.builder().requestType("Colloquia").build();
+		RequestType requestType1 = RequestType.builder().requestType("Colloquia").build();
+
+		when(requestTypeRepository.findAll()).thenReturn(List.of(req));
+
+		Optional<RequestType> requestSaved = requestTypeService.trySave(requestType1);
+
+		verify(requestTypeRepository, times(1)).findAll();
+		verify(requestTypeRepository, times(0)).save(requestType1);
+		assertTrue(requestSaved.isEmpty());
+	}
+
+	@Test
+	void test_trySave_not_exists() {
+		RequestType req = RequestType.builder().requestType("CS Major").build();
+		RequestType requestType1 = RequestType.builder().requestType("Colloquia").build();
+
+		when(requestTypeRepository.findAll()).thenReturn(List.of(req));
+		when(requestTypeRepository.save(eq(requestType1))).thenReturn(requestType1);
+
+		Optional<RequestType> requestSaved = requestTypeService.trySave(requestType1);
+
+		verify(requestTypeRepository, times(1)).findAll();
+		verify(requestTypeRepository, times(1)).save(requestType1);
+		assertTrue(requestSaved.isPresent());
+		assertEquals(requestType1, requestSaved.get());
+	}
+
+	@Test
+	void test_trySaveList() {
+		RequestType req0 = RequestType.builder().requestType("CS Major").build();
+		RequestType req1 = RequestType.builder().requestType("BS/MS").build();
+		RequestType req2 = RequestType.builder().requestType("Office Hours").build();
+		RequestType requestType0 = RequestType.builder().id(0L).requestType("Colloquia").build();
+		RequestType requestType1 = RequestType.builder().requestType("Office Hours").build();
+		RequestType requestType2 = RequestType.builder().requestType("PhD").build();
+
+		when(requestTypeRepository.findAll()).thenReturn(List.of(req0, req1, req2));
+		when(requestTypeRepository.save(eq(requestType0))).thenReturn(requestType0);
+		when(requestTypeRepository.save(eq(requestType2))).thenReturn(requestType2);
+
+		List<RequestType> requestSaved = requestTypeService.trySaveTypes(List.of(requestType0,requestType1,requestType2));
+
+		verify(requestTypeRepository, times(3)).findAll();
+		verify(requestTypeRepository, times(1)).save(requestType0);
+		verify(requestTypeRepository, times(0)).save(requestType1);
+		verify(requestTypeRepository, times(1)).save(requestType2);
+		assertEquals(List.of(requestType0,requestType2), requestSaved);
+	}
+}


### PR DESCRIPTION
This PR implements the backend and relevant tests for the RequestType table. 

The RequestType table consists of an id field and a requestType string.

Only Instructors and Admins can use `put`, `edit`, and `delete` operations, but all users can use `get` operations. 

Attempting to save a duplicate RequestType string will result in a BadRequest Error, returning a custom EntityAlreadyExistsException. 

The changes in workflow 82 is a result of merging with main, but the rest has to do with implementing the backend.

Closes #38 