### PR TITLE
LD - RequestType Post and Get Operations

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/ApiController.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.rec.controllers;
 
+import edu.ucsb.cs156.rec.errors.EntityAlreadyExistsException;
 import edu.ucsb.cs156.rec.errors.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -46,6 +47,20 @@ public abstract class ApiController {
   @ExceptionHandler({ EntityNotFoundException.class })
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public Object handleGenericException(Throwable e) {
+    return Map.of(
+      "type", e.getClass().getSimpleName(),
+      "message", e.getMessage()
+    );
+  }
+
+  /**
+   * This method handles the EntityAlreadyExistsException.
+   * @param e the exception
+   * @return a map with the type and message of the exception
+   */
+  @ExceptionHandler({ EntityAlreadyExistsException.class })
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public Object handleGenericException(EntityAlreadyExistsException e) {
     return Map.of(
       "type", e.getClass().getSimpleName(),
       "message", e.getMessage()

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
@@ -1,0 +1,80 @@
+package edu.ucsb.cs156.rec.controllers;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.errors.EntityNotFoundException;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import edu.ucsb.cs156.rec.services.RequestTypeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * This is a REST controller for Request Types
+ */
+
+@Tag(name = "RequestTypes")
+@RequestMapping("/api/requesttypes")
+@RestController
+@Slf4j
+public class RequestTypesController extends ApiController {
+
+    @Autowired
+    RequestTypeRepository requestTypeRepository;
+
+	@Autowired
+	RequestTypeService requestTypeService;
+
+    /**
+     * This method returns a list of all request types.
+     * @return a list of all request types
+     */
+    @Operation(summary = "List all request types")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<RequestType> allRequestTypes() {
+        Iterable<RequestType> requestTypes = requestTypeRepository.findAll();
+        return requestTypes;
+    }
+
+    /**
+     * This method returns a single request type.
+     * @param id id of the request type to get
+     * @return a single request type
+     */
+    @Operation(summary = "Get a single request type")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public RequestType getById(
+            @Parameter(name = "id") @RequestParam Long id) {
+		RequestType requestType = requestTypeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RequestType.class, id));
+
+        return requestType;
+    }
+
+    /**
+     * This method creates a new request type. Accessible only to users with the role "ROLE_ADMIN" or "ROLE_INSTRUCTOR".
+     * @param requestType description of the request type
+     * @return the save request type (with it's id field set by the database)
+     */
+    @Operation(summary = "Create a new request type")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_INSTRUCTOR')")
+    @PostMapping("/post")
+    public RequestType postRequestType(
+            @Parameter(name = "requestType") @RequestParam String requestType) {
+
+        RequestType savingRequestType = new RequestType();
+        savingRequestType.setRequestType(requestType);
+
+        return requestTypeService.trySave(savingRequestType);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
@@ -1,0 +1,231 @@
+package edu.ucsb.cs156.rec.controllers;
+
+import edu.ucsb.cs156.rec.repositories.UserRepository;
+import edu.ucsb.cs156.rec.testconfig.TestConfig;
+import edu.ucsb.cs156.rec.ControllerTestCase;
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.errors.EntityAlreadyExistsException;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import edu.ucsb.cs156.rec.services.RequestTypeService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = RequestTypesController.class)
+@Import(TestConfig.class)
+public class RequestTypesControllerTests extends ControllerTestCase {
+
+        @MockBean
+        RequestTypeRepository requestTypeRepository;
+
+        @MockBean
+        RequestTypeService requestTypeService;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/phones/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/requesttypes?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // Authorization tests for /api/phones/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/requesttypes/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/requesttypes/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                RequestType requestType = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeRepository.findById(eq(7L))).thenReturn(Optional.of(requestType));  // Check not sure why id is 7
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/requesttypes?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(requestTypeRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(requestType);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(requestTypeRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/requesttypes?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(requestTypeRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("RequestType with id 7 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_request_types() throws Exception {
+
+                // arrange
+                
+                RequestType requestType1 = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+                
+                RequestType requestType2 = RequestType.builder()
+                                .requestType("Office Hours")
+                                .build();
+
+                ArrayList<RequestType> expectedRequestTypes = new ArrayList<>();
+                expectedRequestTypes.addAll(Arrays.asList(requestType1, requestType2));
+
+                when(requestTypeRepository.findAll()).thenReturn(expectedRequestTypes);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(requestTypeRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedRequestTypes);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_request_type() throws Exception {
+                // arrange
+
+                RequestType requestType1 = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeService.trySave(eq(requestType1))).thenReturn(requestType1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/requesttypes/post?requestType=Colloquia")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(requestTypeService, times(1)).trySave(requestType1);
+                String expectedJson = mapper.writeValueAsString(requestType1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "INSTRUCTOR", "USER" })
+        @Test
+        public void an_instructor_can_post_a_new_request_type() throws Exception {
+                // arrange
+
+                RequestType requestType1 = RequestType.builder()
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeService.trySave(eq(requestType1))).thenReturn(requestType1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/requesttypes/post?requestType=Colloquia")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(requestTypeService, times(1)).trySave(requestType1);
+                String expectedJson = mapper.writeValueAsString(requestType1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_post_a_duplicate_request_type() throws Exception {
+                // arrange
+                RequestType requestType1 = RequestType.builder().id(0L)
+                                .requestType("Colloquia")
+                                .build();
+
+                when(requestTypeService.trySave(requestType1)).thenThrow(new EntityAlreadyExistsException(RequestType.class, requestType1.getRequestType()));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/requesttypes/post?requestType=Colloquia")
+                                                .with(csrf()))
+                                .andExpect(status().isBadRequest()).andReturn();
+
+                // assert
+                verify(requestTypeService, times(1)).trySave(requestType1);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityAlreadyExistsException", json.get("type"));
+                assertEquals("RequestType Colloquia already exists", json.get("message"));
+		}
+}


### PR DESCRIPTION
Dependent on #42  and #44

### Description:
 - This PR creates the basic controller with `post` and `get` operations for Request Type.
 - The `post` operation only saves a type if it is unique within the repository, otherwise throws a 400 BadRequest Error

### Tests:
 - Needs RequestType repository and service classes in the codebase, will rerun tests once #42 and #44 merged

### Dokku:
 - Deployed at https://proj-req-type-cr.dokku-07.cs.ucsb.edu/
 - To test, log in as an admin, then use swagger to interact with the repo

### Issues:
 - Closes #45
