### PR TITLE
NW - Add QA and Prod links to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,40 @@
 
 Recommendation Request Manager
 
-Sprint Planning Doc for F24:
-* <https://docs.google.com/document/d/1XsaIPgepB4uA3owsH8eszXbW2mHFTuW5_bT49K8PcuU/edit?tab=t.0>
+#### Deployments:
+
+Prod: https://team07-proj-rec-prod.dokku-07.cs.ucsb.edu/
+
+QA: https://team07-proj-rec-qa.dokku-07.cs.ucsb.edu/
+
+#### Sprint Planning Doc for F24:
+
+- <https://docs.google.com/document/d/1XsaIPgepB4uA3owsH8eszXbW2mHFTuW5_bT49K8PcuU/edit?tab=t.0>
 
 # Versions
-* Java: 21
-* node: 20.17.0
-See [docs/versions.md](docs/versions.md) for more information on upgrading versions.
+
+- Java: 21
+- node: 20.17.0
+  See [docs/versions.md](docs/versions.md) for more information on upgrading versions.
 
 # Setup before running application
 
 Before running the application for the first time,
 you need to do the steps documented in [`docs/oauth.md`](docs/oauth.md).
 
-Otherwise, when you try to login for the first time, you 
+Otherwise, when you try to login for the first time, you
 will likely see an error such as:
 
 <img src="https://user-images.githubusercontent.com/1119017/149858436-c9baa238-a4f7-4c52-b995-0ed8bee97487.png" alt="Authorization Error; Error 401: invalid_client; The OAuth client was not found." width="400"/>
 
 # Getting Started on localhost
 
-* Open *two separate terminal windows*  
-* In the first window, start up the backend with:
-  ``` 
+- Open _two separate terminal windows_
+- In the first window, start up the backend with:
+  ```
   mvn spring-boot:run
   ```
-* In the second window:
+- In the second window:
   ```
   cd frontend
   npm install  # only on first run or when dependencies change
@@ -36,7 +44,7 @@ will likely see an error such as:
 
 Then, the app should be available on <http://localhost:8080>
 
-If it doesn't work at first, e.g. you have a blank page on  <http://localhost:8080>, give it a minute and a few page refreshes.  Sometimes it takes a moment for everything to settle in.
+If it doesn't work at first, e.g. you have a blank page on <http://localhost:8080>, give it a minute and a few page refreshes. Sometimes it takes a moment for everything to settle in.
 
 If you see the following on localhost, make sure that you also have the frontend code running in a separate window.
 
@@ -52,50 +60,54 @@ See: [/docs/dokku.md](/docs/dokku.md)
 
 To access the swagger API endpoints, use:
 
-* <http://localhost:8080/swagger-ui/index.html>
+- <http://localhost:8080/swagger-ui/index.html>
 
 Or add `/swagger-ui/index.html` to the URL of your dokku deployment.
 
 # To run React Storybook
 
-* cd into frontend
-* use: npm run storybook
-* This should put the storybook on http://localhost:6006
-* Additional stories are added under frontend/src/stories
+- cd into frontend
+- use: npm run storybook
+- This should put the storybook on http://localhost:6006
+- Additional stories are added under frontend/src/stories
 
-For documentation on React Storybook, see: 
-* <https://ucsb-cs156.github.io/topics/storybook/>
-* <https://ucsb-cs156.github.io/topics/chromatic/>
-* <https://storybook.js.org/>
+For documentation on React Storybook, see:
+
+- <https://ucsb-cs156.github.io/topics/storybook/>
+- <https://ucsb-cs156.github.io/topics/chromatic/>
+- <https://storybook.js.org/>
 
 # SQL Database access
 
 On localhost:
-* The SQL database is an H2 database and the data is stored in a file under `target`
-* Each time you do `mvn clean` the database is completely rebuilt from scratch
-* You can access the database console via a special route, <http://localhost:8080/h2-console>
-* For more info, see [docs/h2-database.md](/docs/h2-database.md)
+
+- The SQL database is an H2 database and the data is stored in a file under `target`
+- Each time you do `mvn clean` the database is completely rebuilt from scratch
+- You can access the database console via a special route, <http://localhost:8080/h2-console>
+- For more info, see [docs/h2-database.md](/docs/h2-database.md)
 
 On Dokku, follow instructions for Dokku databases:
-* <https://ucsb-cs156.github.io/topics/dokku/postgres_database.html>
+
+- <https://ucsb-cs156.github.io/topics/dokku/postgres_database.html>
 
 # Testing
 
 ## Unit Tests
 
-* To run all unit tests, use: `mvn test`
-* To run only the tests from `FooTests.java` use: `mvn test -Dtest=FooTests`
+- To run all unit tests, use: `mvn test`
+- To run only the tests from `FooTests.java` use: `mvn test -Dtest=FooTests`
 
 Unit tests are any methods labelled with the `@Test` annotation that are under the `/src/test/java` hierarchy, and have file names that end in `Test` or `Tests`
 
 ## Integration Tests
 
 To run only the integration tests, use:
+
 ```
 INTEGRATION=true mvn test-compile failsafe:integration-test
 ```
 
-To run only the integration tests *and* see the tests run as you run them,
+To run only the integration tests _and_ see the tests run as you run them,
 use:
 
 ```
@@ -109,6 +121,7 @@ INTEGRATION=true mvn test-compile failsafe:integration-test -Dit.test=HomePageWe
 ```
 
 or to see it run live:
+
 ```
 INTEGRATION=true HEADLESS=false mvn test-compile failsafe:integration-test -Dit.test=HomePageWebIT
 ```
@@ -117,10 +130,9 @@ Integration tests are any methods labelled with `@Test` annotation, that are und
 
 By convention, we are putting Integration tests (the ones that run with Playwright) under the package `src/test/java/edu/ucsb/cs156/example/web`.
 
-Unless you want a particular integration test to *also* be run when you type `mvn test`, do *not* use the suffixes `Test` or `Tests` for the filename.
+Unless you want a particular integration test to _also_ be run when you type `mvn test`, do _not_ use the suffixes `Test` or `Tests` for the filename.
 
 Note that while `mvn test` is typically sufficient to run tests, we have found that if you haven't compiled the test code yet, running `mvn failsafe:integration-test` may not actually run any of the tests.
-
 
 ## Partial pitest runs
 


### PR DESCRIPTION
#### Description:
- Set up both the QA and Prod deployments, added their links to the Readme.
- Formatted the Readme file as well.

#### Links:
- Prod: https://team07-proj-rec-prod.dokku-07.cs.ucsb.edu/

- QA: https://team07-proj-rec-qa.dokku-07.cs.ucsb.edu/

#### Testing:
- Google OAuth, Swagger work on both QA and Deployment.
- Database updates, (`GET`, `POST`, `PUT`, etc.) work as expected.

#### Further Notes:
- Deploying a branch to QA, as well as a general bash script for deploying new apps, has instructions posted in the team Slack channel.

#### Related Issues:
Closes #21 and #22 
